### PR TITLE
Added support for variable length null terminated strings

### DIFF
--- a/jspack.js
+++ b/jspack.js
@@ -59,8 +59,8 @@ function JSPack()
 	// ASCII character strings null terminated
 	m._DeNullString = function (a, p, l, v)
 	{
-        	var str = m._DeString(a, p, l, v);
-          	return str.substring(0, str.length - 1);
+		var str = m._DeString(a, p, l, v);
+		return str.substring(0, str.length - 1);
 	};
 
 	// Little-endian N-bit IEEE 754 floating point


### PR DESCRIPTION
This uses the 'S' format character. Due to the inability to precalculate the width, 'S' doesn't work with CalcLength() or Pack(). PackTo and Unpack work fine.
